### PR TITLE
Fixed ball collider scaling

### DIFF
--- a/Assets/_Project/Resources/Prefabs/ball/local_ball.prefab
+++ b/Assets/_Project/Resources/Prefabs/ball/local_ball.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: -5041603410156504418}
   - component: {fileID: 8513355890668319001}
   m_Layer: 6
-  m_Name: ball
+  m_Name: local_ball
   m_TagString: Ball
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -102,7 +102,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 1.31
+  m_Radius: 1.179
 --- !u!114 &-5041603410156504418
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Resources/Prefabs/ball/local_bomb.prefab
+++ b/Assets/_Project/Resources/Prefabs/ball/local_bomb.prefab
@@ -97,7 +97,7 @@ GameObject:
   - component: {fileID: 4631669078464913006}
   - component: {fileID: 6386409543597649593}
   m_Layer: 22
-  m_Name: bomb
+  m_Name: local_bomb
   m_TagString: Ball
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -217,7 +217,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: -0.01}
   serializedVersion: 2
-  m_Radius: 1.5
+  m_Radius: 1.179
 --- !u!114 &6386409543597649593
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Resources/Prefabs/ball/online_ball.prefab
+++ b/Assets/_Project/Resources/Prefabs/ball/online_ball.prefab
@@ -102,7 +102,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 1.31
+  m_Radius: 1.179
 --- !u!114 &3644242133981255611
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/_Project/Resources/Prefabs/ball/online_bomb.prefab
+++ b/Assets/_Project/Resources/Prefabs/ball/online_bomb.prefab
@@ -229,7 +229,7 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: -0.01}
   serializedVersion: 2
-  m_Radius: 1.5
+  m_Radius: 1.179
 --- !u!1 &3090316126077261480
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Ball collider radius is now multiplied times the transform scale.
For some reason Unity doesn't apply the scaling to the collider automatically.
The ball and its shadow are now positioned correctly.
Closes #23 
Closes #9